### PR TITLE
Set an rtpFilePath on tmuxPlugins.weather

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -770,6 +770,7 @@ in rec {
 
   weather = mkTmuxPlugin {
     pluginName = "weather";
+    rtpFilePath = "tmux-weather.tmux";
     version = "unstable-2020-02-08";
     src = fetchFromGitHub {
       owner = "xamut";


### PR DESCRIPTION
The default RTP file path becomes `weather.tmux`, which does not exist. Set it to `tmux-weather.tmux` instead.